### PR TITLE
External DICOM upload endpoint with static API key authentication

### DIFF
--- a/design/radiology-openapi.yaml
+++ b/design/radiology-openapi.yaml
@@ -520,6 +520,79 @@ paths:
         '401':
           $ref: '#/components/responses/Unauthorized'
 
+  /api/care_radiology/dicom/upload-dicom-external/:
+    post:
+      tags:
+        - DICOM Studies
+      summary: Upload DICOM file (external / static API key)
+      description: |
+        Upload a DICOM (.dcm) file for a patient using a static API key instead of
+        user JWT auth. Intended for machine-to-machine use (e.g. modality worklist
+        server, HIS integration). The file is forwarded to DCM4CHEE and a `DicomStudy`
+        record is created or updated in CARE.
+
+        Authenticated with static API key (Authorization: <CARE_RADIOLOGY_WEBHOOK_SECRET>).
+        No user permission check is performed.
+      operationId: dicomUploadExternal
+      security:
+        - StaticApiKey: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - patient_id
+                - file
+              properties:
+                patient_id:
+                  type: string
+                  format: uuid
+                  description: Patient external_id
+                file:
+                  type: string
+                  format: binary
+                  description: DICOM (.dcm) file
+      responses:
+        '201':
+          description: DICOM file uploaded and study record created/updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "DICOM file uploaded to DCM4CHE successfully"
+                  study_uid:
+                    type: string
+                    description: DICOM Study Instance UID
+                    example: "1.2.840.10008.5.1.4.1.1.2.1234"
+                  study:
+                    $ref: '#/components/schemas/DicomStudyDetail'
+        '400':
+          description: No file provided
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "No file provided"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '502':
+          description: DCM4CHEE upload failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Failed to upload to DCM4CHE"
+                status_code: 503
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/care_radiology/dicom/upload/:
     post:
       tags:

--- a/src/care_radiology/api/dicom.py
+++ b/src/care_radiology/api/dicom.py
@@ -31,19 +31,17 @@ from care_radiology.models.study_report import StudyReport
 DCM4CHEE_BASEURL = settings.PLUGIN_CONFIGS['care_radiology']['CARE_RADIOLOGY_DCM4CHEE_DICOMWEB_BASEURL']
 STATIC_API_KEY = settings.PLUGIN_CONFIGS['care_radiology']['CARE_RADIOLOGY_WEBHOOK_SECRET']
 
-class StaticAPIKeyAuthentication(BaseAuthentication, BasePermission):
+class StaticAPIKeyAuthentication(BaseAuthentication):
     def authenticate(self, request):
         api_key = request.headers.get("Authorization")
         if api_key == STATIC_API_KEY:
             return (AnonymousUser(), None)
         raise AuthenticationFailed("Invalid API key")
 
-    def has_permission(self, request):
+class StaticAPIKeyAuthorization(BasePermission):
+    def has_permission(self, request, view):
         api_key = request.headers.get("Authorization")
-        if api_key == STATIC_API_KEY:
-            return (AnonymousUser(), None)
-        raise AuthenticationFailed("Invalid API key")
-
+        return api_key == STATIC_API_KEY
 
 
 class DICOM_TAG(Enum):
@@ -161,6 +159,85 @@ class DicomViewSet(ViewSet):
                 return Response(
                     data={
                         "message": "DICOM file uploaded to Orthanc successfully",
+                        "study_uid": study_uid,
+                        "study": fetch_study(dicom_study),
+                    },
+                    status=201,
+                )
+
+            else:
+                return Response(
+                    data={
+                        "error": "Failed to upload to DCM4CHE",
+                        "status_code": upload_response.status_code,
+                    },
+                    status=502,
+                )
+
+        except Exception as e:
+            return Response(
+                data={"error": "Exception occurred", "details": str(e)}, status=500
+            )
+
+    # DCM Files upload via static API key (no user auth required)
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="upload-dicom-external",
+        authentication_classes=[StaticAPIKeyAuthentication],
+        permission_classes=[StaticAPIKeyAuthorization],
+    )
+    def upload_with_key(self, request):
+        patient = Patient.objects.get(external_id=request.data.get("patient_id"))
+        dcm_file = request.FILES.get("file")
+
+        if not dcm_file:
+            return Response({"error": "No file provided"}, status=400)
+
+        try:
+            body, content_type = encode_file_multipart_related(dcm_file)
+            upload_response = requests.post(
+                url=f"{DCM4CHEE_BASEURL}/rs/studies",
+                data=body,
+                headers={
+                    "Content-Type": content_type,
+                    "Accept": "application/dicom+json",
+                },
+            )
+
+            if upload_response.status_code in [200, 201]:
+                refenrenced_sop = d_find(
+                    upload_response.json(), DICOM_TAG.ReferencedSOPSQ.value
+                )[0]
+
+                instance_uid = d_find(
+                    refenrenced_sop, DICOM_TAG.ReferencedInstanceUID.value
+                )[0]
+
+                study_uid = d_find(
+                    d_query_instance(instance_uid), DICOM_TAG.StudyInstanceUID.value
+                )[0]
+
+                studies_qs = DicomStudy.objects.annotate(
+                    has_report=Exists(
+                        StudyReport.objects.filter(study=OuterRef("pk"))
+                    )
+                )
+
+                (dicom_study, _) = DicomStudy.objects.update_or_create(
+                    dicom_study_uid=study_uid,
+                    patient=patient,
+                    defaults={},
+                )
+
+                dicom_study = studies_qs.get(pk=dicom_study.pk)
+
+                key = f"radiology:dicom:study:{study_uid}"
+                cache.delete(key)
+
+                return Response(
+                    data={
+                        "message": "DICOM file uploaded to DCM4CHE successfully",
                         "study_uid": study_uid,
                         "study": fetch_study(dicom_study),
                     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new external DICOM upload API endpoint for machine-to-machine integration, authenticated via static API key. The endpoint accepts DICOM files associated with a patient and returns the corresponding study details upon successful upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->