### PR TITLE
added mpps_handler

### DIFF
--- a/docker-compose.radiology.yaml
+++ b/docker-compose.radiology.yaml
@@ -14,6 +14,12 @@ services:
 
   arc:
     image: dcm4che/dcm4chee-arc-psql:5.34.1
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "9990:9990"
+      - "2575:2575"
+      - "11112:11112"
     logging:
       driver: json-file
       options:

--- a/docker/nginx-proxy/nginx.conf
+++ b/docker/nginx-proxy/nginx.conf
@@ -20,32 +20,44 @@ http {
         # ssl_certificate_key /etc/nginx/conf.d/priv.key;
 
         # AC Headers ----------------------------------------------------------
-        add_header 'Access-Control-Allow-Origin' '*' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' '*' always;
-        add_header 'Access-Control-Allow-Credentials' 'true' always;
+        # add_header 'Access-Control-Allow-Origin' '*' always;
+        # add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+        # add_header 'Access-Control-Allow-Headers' '*' always;
+        # add_header 'Access-Control-Allow-Credentials' 'true' always;
 
         # OHIF Viwer ----------------------------------------------------------
+        # location / {
+
+        #     if ($request_method = OPTIONS) {
+        #         return 204;
+        #     }
+
+        #     proxy_pass http://ohif:80;
+        #     proxy_set_header HOST $host;
+        #     proxy_set_header X-Real-IP $remote_addr;
+        #     rewrite /ohif(.*) $1 break;
+        # }
         location / {
 
-            if ($request_method = OPTIONS) {
-                return 204;
-            }
-
             proxy_pass http://ohif:80;
-            proxy_set_header HOST $host;
+            proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            rewrite /ohif(.*) $1 break;
+
+            # IMPORTANT: no rewrite here
         }
 
         # DCM4CHE Server ------------------------------------------------------
         location /dicomweb/ {
 
             if ($request_method = OPTIONS) {
+                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+                add_header 'Access-Control-Allow-Headers' '*' always;
+                add_header 'Access-Control-Allow-Credentials' 'true' always;
                 return 204;
             }
 
-            auth_request /authenticate;
+            # auth_request /authenticate;
 
             # Don't pass auth headers to DCM4CHE
             proxy_set_header authorization "";
@@ -55,6 +67,20 @@ http {
             proxy_set_header HOST $host;
             proxy_set_header X-Real-IP $remote_addr;
             rewrite /dicomweb(.*) $1 break;
+        }
+
+        # DCM4CHEE UI (FIXED)
+        location /dcm4chee-arc/ {
+            proxy_pass http://arc:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+
+            # IMPORTANT FIXES
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+
+            # Do NOT rewrite paths
+            proxy_redirect off;
         }
 
         # Authentication Endpoint ---------------------------------------------

--- a/docker/ohif/app-config.js
+++ b/docker/ohif/app-config.js
@@ -30,9 +30,9 @@ window.config = {
       configuration: {
         friendlyName: 'DCM4CHE Server',
         name: 'dcm4che_server',
-        wadoUriRoot: 'https://dicom.example.domain/dicomweb/dcm4chee-arc/aets/DCM4CHEE/wado',
-        qidoRoot: 'https://dicom.example.domain/dicomweb/dcm4chee-arc/aets/DCM4CHEE/rs',
-        wadoRoot: 'https://dicom.example.domain/dicomweb/dcm4chee-arc/aets/DCM4CHEE/rs',
+        wadoUriRoot: 'http://localhost:32314/dicomweb/dcm4chee-arc/aets/DCM4CHEE/wado',
+        qidoRoot: 'http://localhost:32314/dicomweb/dcm4chee-arc/aets/DCM4CHEE/rs',
+        wadoRoot: 'http://localhost:32314/dicomweb/dcm4chee-arc/aets/DCM4CHEE/rs',
         qidoSupportsIncludeField: false,
         imageRendering: 'wadors',
         thumbnailRendering: 'wadors',

--- a/src/care_radiology/api/dicom.py
+++ b/src/care_radiology/api/dicom.py
@@ -167,6 +167,16 @@ class DicomViewSet(ViewSet):
                 )
 
             else:
+                import logging
+                logger = logging.getLogger(__name__)
+                logger.info("Inside the else block")
+                logger.info(f"Upload Response Status: {upload_response.status_code}")
+
+                logger.error(f"Response Body: {upload_response.text}")
+                logger.error("\n")
+                
+                logger.error(f"Response JSON: {upload_response.json()}")  # if response is JSON
+
                 return Response(
                     data={
                         "error": "Failed to upload to DCM4CHE",
@@ -174,6 +184,7 @@ class DicomViewSet(ViewSet):
                     },
                     status=502,
                 )
+
 
         except Exception as e:
             return Response(

--- a/src/care_radiology/api/webhooks.py
+++ b/src/care_radiology/api/webhooks.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-
+import logging
 from rest_framework.viewsets import ViewSet
 from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
@@ -15,9 +15,13 @@ from care.emr.models.patient import Patient
 from care.emr.models.service_request import ServiceRequest
 from care_radiology.models.dicom_study import DicomStudy
 from care_radiology.models.webhook_logs import RadiologyWebhookLogs
-from care_radiology.models.radiology_service_request import RadiologyServiceRequest
+from care_radiology.models.radiology_service_request import (
+    RadiologyServiceRequest,
+)
 
-STATIC_API_KEY = settings.PLUGIN_CONFIGS['care_radiology']['CARE_RADIOLOGY_WEBHOOK_SECRET']
+STATIC_API_KEY = settings.PLUGIN_CONFIGS["care_radiology"][
+    "CARE_RADIOLOGY_WEBHOOK_SECRET"
+]
 
 
 class StaticAPIKeyAuthentication(BaseAuthentication):
@@ -26,6 +30,9 @@ class StaticAPIKeyAuthentication(BaseAuthentication):
         if api_key == STATIC_API_KEY:
             return (AnonymousUser(), None)
         raise AuthenticationFailed("Invalid API key")
+
+
+logger = logging.getLogger(__name__)
 
 
 class WebhookViewSet(ViewSet):
@@ -50,28 +57,37 @@ class WebhookViewSet(ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        RadiologyWebhookLogs.objects.create(raw_data=data, type="SR-STUDY-INSERT")
+        RadiologyWebhookLogs.objects.create(
+            raw_data=data, type="SR-STUDY-INSERT"
+        )
         if not isinstance(data, dict):
             return Response(
                 {"detail": "JSON object expected"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-
         if data.get("service_request_id") and data.get("study_id"):
             try:
-                sr = ServiceRequest.objects.get(external_id=data["service_request_id"])
+                sr = ServiceRequest.objects.get(
+                    external_id=data["service_request_id"]
+                )
             except ServiceRequest.DoesNotExist:
                 return Response(
                     {"detail": "No matching service request"},
                     status=status.HTTP_409_CONFLICT,
                 )
             (study, ds_created) = DicomStudy.objects.get_or_create(
-                dicom_study_uid=data.get("study_id"), patient=sr.patient, defaults={}
+                dicom_study_uid=data.get("study_id"),
+                patient=sr.patient,
+                defaults={},
             )
             if sr and study:
-                (rsr, rsr_created) = RadiologyServiceRequest.objects.update_or_create(
-                    service_request=sr, dicom_study=study, defaults={"raw_data": data}
+                (rsr, rsr_created) = (
+                    RadiologyServiceRequest.objects.update_or_create(
+                        service_request=sr,
+                        dicom_study=study,
+                        defaults={"raw_data": data},
+                    )
                 )
 
             return Response(
@@ -84,9 +100,12 @@ class WebhookViewSet(ViewSet):
                 },
                 status=status.HTTP_200_OK,
             )
+
         elif data.get("patient_id") and data.get("study_id"):
             patient = Patient.objects.filter(
-                instance_identifiers__contains=[{"value": data.get("patient_id")}]
+                instance_identifiers__contains=[
+                    {"value": data.get("patient_id")}
+                ]
             ).first()
             if not patient:
                 return Response(
@@ -94,9 +113,11 @@ class WebhookViewSet(ViewSet):
                     status=status.HTTP_409_CONFLICT,
                 )
             (study, ds_created) = DicomStudy.objects.get_or_create(
-                dicom_study_uid=data.get("study_id"), patient = patient, defaults={}
+                dicom_study_uid=data.get("study_id"),
+                patient=patient,
+                defaults={},
             )
-            if (patient and study):
+            if patient and study:
                 return Response(
                     {
                         "detail": "Webhook received and saved successfully",
@@ -111,6 +132,176 @@ class WebhookViewSet(ViewSet):
         return Response(
             {
                 "detail": "Webhook received and saved successfully",
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="mpps",
+        permission_classes=[AllowAny],
+    )
+    def handle_mpps(self, request):
+        """
+        Handle MPPS status updates from DICOM enabler
+        Updates ServiceRequest tags in CARE
+        """
+        logger.info("[MPPS] Webhook received!")
+        print("[MPPS] Webhook received!")  # Also print to console
+        # Step 1: Authenticate
+        authenticator = StaticAPIKeyAuthentication()
+        try:
+            authenticator.authenticate(request)
+            logger.info("[MPPS] Authentication passed")
+        except AuthenticationFailed:
+            logger.error("[MPPS] Authentication failed")
+            return Response(
+                {"detail": "Invalid API key"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        # Step 2: Parse webhook data
+        try:
+            data = request.data
+            logger.info(f"[MPPS] Received data: {data}")
+            print(f"[MPPS] Received data: {data}")
+        except ParseError:
+            logger.error("[MPPS] Invalid JSON payload")
+            return Response(
+                {"detail": "Invalid JSON payload"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Step 3: Extract fields
+        service_request_id = data.get("service_request_id")
+        mpps_status = data.get("mpps_status")
+        study_id = data.get("study_id")
+        logger.info(
+            f"[MPPS] Extracted - SR: {service_request_id}, Status: {mpps_status}"
+        )
+
+        # Step 4: Validate required fields
+        if not service_request_id or not mpps_status:
+            logger.error("[MPPS] Missing required fields")
+            return Response(
+                {
+                    "detail": "Missing required fields: service_request_id, mpps_status"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Log the webhook
+        RadiologyWebhookLogs.objects.create(raw_data=data, type="MPPS")
+        logger.info("[MPPS] Webhook logged to database")
+
+        # Step 5: Get ServiceRequest from CARE
+        try:
+            sr = ServiceRequest.objects.get(external_id=service_request_id)
+            logger.info(f"[MPPS] ServiceRequest found: {sr.id}")
+        except ServiceRequest.DoesNotExist:
+            logger.error(
+                f"[MPPS] ServiceRequest not found: {service_request_id}"
+            )
+            return Response(
+                {"detail": f"Service request not found: {service_request_id}"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Step 6: Get facility from ServiceRequest
+        facility = sr.facility
+        if not facility:
+            logger.error("[MPPS] Facility not found for SR")
+            return Response(
+                {"detail": "Facility not found for service request"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        logger.info(f"[MPPS] Facility found: {facility.external_id}")
+        # Step 7: Get TagConfig for MPPS status
+        from care.emr.models.tag_config import TagConfig
+
+        try:
+            tag_config = TagConfig.objects.filter(
+                facility=facility, display=mpps_status  # e.g., "STARTED"
+            ).first()
+
+            if not tag_config:
+                logger.error(f"[MPPS] Tag not found for status: {mpps_status}")
+                return Response(
+                    {
+                        "detail": f"Tag configuration not found for status: {mpps_status}"
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            tag_uuid = tag_config.external_id
+            logger.info(f"[MPPS] Tag found: {tag_uuid}")
+        except Exception as e:
+            logger.error(f"[MPPS] Error fetching tag: {str(e)}")
+            return Response(
+                {"detail": f"Error fetching tag configuration: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        # Step 8: Call CARE's set_tags API via HTTP with stored authentication
+        try:
+            import requests
+            from django.core.cache import cache
+
+            set_tags_url = f"http://localhost:9000/api/v1/facility/{facility.external_id}/service_request/{service_request_id}/set_tags/"
+
+            payload = {"tags": [str(tag_uuid)]}
+            logger.info(f"[MPPS] Calling set_tags API: {set_tags_url}")
+            logger.info(f"[MPPS] Payload: {payload}")
+
+            # Step 8a: Get cached access token or fetch new one
+            access_token = cache.get("admin_access_token")
+
+            if not access_token:
+                logger.info(
+                    "[MPPS] Access token not in cache, fetching new one..."
+                )
+                login_url = "http://localhost:9000/api/v1/auth/login/"
+                login_payload = {"username": "admin", "password": "admin"}
+
+                login_response = requests.post(login_url, json=login_payload)
+                login_response.raise_for_status()
+
+                access_token = login_response.json().get("access")
+                # Cache the token for 10 minutes (600 seconds)
+                cache.set("admin_access_token", access_token, 600)
+                logger.info("[MPPS] New access token obtained and cached")
+            else:
+                logger.info("[MPPS] Using cached access token")
+
+            # Step 8b: Call set_tags with the token
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {access_token}",
+            }
+
+            response = requests.post(
+                set_tags_url, json=payload, headers=headers
+            )
+            logger.info(f"[MPPS] set_tags response: {response.status_code}")
+            response.raise_for_status()
+
+        except Exception as e:
+            logger.error(f"[MPPS] Error calling set_tags API: {str(e)}")
+            return Response(
+                {"detail": f"Error calling set_tags API: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        # Step 9: Return success
+        logger.info("[MPPS] Success! Tag updated")
+        return Response(
+            {
+                "detail": "MPPS status tag updated successfully",
+                "service_request_id": service_request_id,
+                "mpps_status": mpps_status,
+                "tag_uuid": str(tag_uuid),
             },
             status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new radiology webhook workflow that can update study tags based on MPPS status.
  * Improved DICOM and OHIF connectivity so the web app can reach local radiology services more reliably.

* **Bug Fixes**
  * Enhanced upload error handling with clearer logging when a DICOM transfer fails.
  * Updated proxy and route handling to better support browser requests, including preflight and credentialed access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an MPPS (Modality Performed Procedure Step) webhook handler that receives DICOM status updates and propagates them as tags on the corresponding CARE `ServiceRequest` via an internal HTTP call-back. It also adds a new `/dcm4chee-arc/` nginx proxy location, exposes additional DCM4CHE ports, and includes debug logging in the DICOM upload error path.

- **`handle_mpps` webhook** (`webhooks.py`): Authenticates the incoming webhook, looks up the `ServiceRequest` and its facility, resolves a `TagConfig` by MPPS status string, then logs into the CARE API with hardcoded `admin`/`admin` credentials and a hardcoded `localhost:9000` URL to call `set_tags` — both values are unsuitable for any real deployment.
- **nginx changes** (`nginx.conf`): Global CORS headers were removed and re-added only inside the OPTIONS pre-flight block for `/dicomweb/`, leaving actual DICOMweb GET/POST responses without CORS headers; `auth_request` authentication for `/dicomweb/` was also disabled.
- **OHIF config** (`app-config.js`): DICOMweb server URLs were changed from domain-name placeholders to `http://localhost:32314`, a local development address that will not work in any deployed environment.

<h3>Confidence Score: 1/5</h3>

Not safe to merge: the MPPS handler embeds admin credentials in source code, `auth_request` for DICOMweb is disabled, CORS is broken for actual requests, and internal URLs are hardcoded to localhost.

The MPPS handler hard-codes `admin`/`admin` as the login credential used to obtain a bearer token for CARE API calls, which is a critical security exposure. On top of that, DICOMweb authentication has been commented out in nginx, meaning the DICOM server is currently unprotected. The CORS restructuring breaks cross-origin requests for the OHIF viewer. The localhost URLs mean the new MPPS flow cannot work in the Docker stack at all. Several files carry debug artifacts that indicate this is not yet production-ready.

`src/care_radiology/api/webhooks.py` (hardcoded credentials and localhost URLs) and `docker/nginx-proxy/nginx.conf` (disabled auth and broken CORS) need the most attention before merging.

<details open><summary><h3>Security Review</h3></summary>

- **Hardcoded admin credentials** (`webhooks.py` line 266): The MPPS handler logs into the CARE API using literal `username: "admin"` / `password: "admin"`. Anyone with read access to the source can extract the credential. If the admin account uses this default password, an attacker who can send a valid webhook can trigger admin-level CARE API calls.
- **DICOMweb authentication disabled** (`nginx.conf` line 66): `auth_request /authenticate` is commented out, removing JWT verification from all `/dicomweb/` requests. Any client that can reach nginx can now query or retrieve DICOM studies without authentication.
- **Cached admin token with no invalidation** (`webhooks.py`): The access token is cached under the global key `"admin_access_token"` for 10 minutes with no mechanism to invalidate or rotate it if the admin password changes or the token is revoked early.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/care_radiology/api/webhooks.py | Adds a new `handle_mpps` webhook endpoint that processes MPPS status updates and calls back into the CARE API to set tags — but uses hardcoded admin credentials and hardcoded `localhost:9000` URLs that will not work in a Docker environment. |
| docker/nginx-proxy/nginx.conf | Adds a `/dcm4chee-arc/` proxy location and restructures CORS handling; however, CORS headers are now only emitted on OPTIONS pre-flight responses and not on actual DICOMweb requests, and `auth_request` for the `/dicomweb/` endpoint is disabled. |
| src/care_radiology/api/dicom.py | Adds debug logging in the `upload` error path; `upload_response.json()` is called unconditionally and will raise an exception on non-JSON error responses, causing a 500 instead of 502. Logger is also set up inline rather than at module level. |
| docker/ohif/app-config.js | Replaces example domain placeholders with `http://localhost:32314` — a hardcoded local development address that will break OHIF in any deployed environment. |
| docker-compose.radiology.yaml | Exposes additional DCM4CHE ports (8080, 8443, 9990, 2575, 11112) on the host. Port 9990 is the WildFly/JBoss admin console and should be reviewed before exposing in production. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant DICOM as DICOM Enabler
    participant WebhookView as WebhookViewSet /mpps
    participant DB as Database
    participant TagConfig as TagConfig Model
    participant CARESvc as CARE API (localhost:9000)
    participant Cache as Django Cache

    DICOM->>WebhookView: "POST /mpps {service_request_id, mpps_status, study_id}"
    WebhookView->>WebhookView: Authenticate (StaticAPIKey)
    WebhookView->>DB: "RadiologyWebhookLogs.create(type=MPPS)"
    WebhookView->>DB: ServiceRequest.get(external_id)
    DB-->>WebhookView: sr
    WebhookView->>WebhookView: "facility = sr.facility"
    WebhookView->>TagConfig: "filter(facility, display=mpps_status)"
    TagConfig-->>WebhookView: tag_config.external_id
    WebhookView->>Cache: get(admin_access_token)
    alt Token not cached
        WebhookView->>CARESvc: "POST /api/v1/auth/login/ {username:admin, password:admin}"
        CARESvc-->>WebhookView: access_token
        WebhookView->>Cache: set(admin_access_token, token, 600s)
    else Token cached
        Cache-->>WebhookView: access_token
    end
    WebhookView->>CARESvc: "POST /api/v1/facility/{fid}/service_request/{srid}/set_tags/ Bearer {access_token}"
    CARESvc-->>WebhookView: 200 OK
    WebhookView-->>DICOM: "200 {detail, tag_uuid}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant DICOM as DICOM Enabler
    participant WebhookView as WebhookViewSet /mpps
    participant DB as Database
    participant TagConfig as TagConfig Model
    participant CARESvc as CARE API (localhost:9000)
    participant Cache as Django Cache

    DICOM->>WebhookView: "POST /mpps {service_request_id, mpps_status, study_id}"
    WebhookView->>WebhookView: Authenticate (StaticAPIKey)
    WebhookView->>DB: "RadiologyWebhookLogs.create(type=MPPS)"
    WebhookView->>DB: ServiceRequest.get(external_id)
    DB-->>WebhookView: sr
    WebhookView->>WebhookView: "facility = sr.facility"
    WebhookView->>TagConfig: "filter(facility, display=mpps_status)"
    TagConfig-->>WebhookView: tag_config.external_id
    WebhookView->>Cache: get(admin_access_token)
    alt Token not cached
        WebhookView->>CARESvc: "POST /api/v1/auth/login/ {username:admin, password:admin}"
        CARESvc-->>WebhookView: access_token
        WebhookView->>Cache: set(admin_access_token, token, 600s)
    else Token cached
        Cache-->>WebhookView: access_token
    end
    WebhookView->>CARESvc: "POST /api/v1/facility/{fid}/service_request/{srid}/set_tags/ Bearer {access_token}"
    CARESvc-->>WebhookView: 200 OK
    WebhookView-->>DICOM: "200 {detail, tag_uuid}"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docker/nginx-proxy/nginx.conf`, line 66 ([link](https://github.com/care-ecosystem/care_radiology/blob/403b8ba83994e89d2a322f7357255c5a72e7e48a/docker/nginx-proxy/nginx.conf#L66)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Authentication for DICOMweb endpoint disabled**

   `auth_request /authenticate` has been commented out, removing JWT verification from all DICOMweb (`/dicomweb/`) requests. Any client that can reach the nginx proxy can now query or retrieve DICOM studies without a valid session. If this was disabled for debugging purposes, it should not be merged in this state.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docker%2Fnginx-proxy%2Fnginx.conf%0ALine%3A%2066%0A%0AComment%3A%0A**Authentication%20for%20DICOMweb%20endpoint%20disabled**%0A%0A%60auth_request%20%2Fauthenticate%60%20has%20been%20commented%20out%2C%20removing%20JWT%20verification%20from%20all%20DICOMweb%20%28%60%2Fdicomweb%2F%60%29%20requests.%20Any%20client%20that%20can%20reach%20the%20nginx%20proxy%20can%20now%20query%20or%20retrieve%20DICOM%20studies%20without%20a%20valid%20session.%20If%20this%20was%20disabled%20for%20debugging%20purposes%2C%20it%20should%20not%20be%20merged%20in%20this%20state.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=care-ecosystem%2Fcare_radiology&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%209%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%209%0Asrc%2Fcare_radiology%2Fapi%2Fwebhooks.py%3A265-268%0A**Hardcoded%20admin%20credentials**%0A%0AThe%20login%20payload%20uses%20%60%22username%22%3A%20%22admin%22%2C%20%22password%22%3A%20%22admin%22%60%20as%20literal%20strings.%20Any%20developer%2C%20operator%2C%20or%20third%20party%20who%20can%20read%20this%20source%20file%20%E2%80%94%20or%20the%20logs%20%28which%20print%20the%20received%20MPPS%20data%29%20%E2%80%94%20can%20infer%20the%20admin%20password%20used%20to%20obtain%20a%20bearer%20token%20for%20the%20CARE%20API.%20In%20environments%20where%20the%20admin%20password%20differs%20from%20this%20default%2C%20the%20entire%20MPPS%20tag-update%20flow%20will%20silently%20fail%20with%20a%20401%20from%20the%20login%20endpoint%3B%20in%20environments%20where%20it%20matches%2C%20any%20attacker%20who%20triggers%20this%20webhook%20can%20indirectly%20drive%20admin-level%20API%20calls.%20These%20credentials%20should%20be%20read%20from%20%60settings.PLUGIN_CONFIGS%60%20or%20environment%20variables%2C%20never%20inlined.%0A%0A%23%23%23%20Issue%202%20of%209%0Adocker%2Fnginx-proxy%2Fnginx.conf%3A50-72%0A**CORS%20headers%20absent%20from%20non-OPTIONS%20responses%20to%20%60%2Fdicomweb%2F%60**%0A%0AThe%20four%20%60Access-Control-Allow-*%60%20headers%20are%20now%20placed%20only%20inside%20the%20%60if%20%28%24request_method%20%3D%20OPTIONS%29%60%20block%2C%20so%20they%20are%20returned%20on%20the%20pre-flight%20but%20**not**%20on%20the%20actual%20%60GET%60%2F%60POST%60%20DICOMweb%20requests%20that%20follow.%20Browsers%20enforce%20CORS%20on%20the%20real%20response%2C%20not%20just%20the%20pre-flight%2C%20so%20every%20cross-origin%20WADO%2FQIDO%20request%20from%20the%20OHIF%20viewer%20will%20be%20blocked.%20The%20headers%20either%20need%20to%20be%20placed%20outside%20the%20%60if%60%20block%20in%20the%20%60location%20%2Fdicomweb%2F%60%20context%2C%20or%20re-added%20at%20the%20server%20level.%0A%0A%23%23%23%20Issue%203%20of%209%0Adocker%2Fnginx-proxy%2Fnginx.conf%3A66%0A**Authentication%20for%20DICOMweb%20endpoint%20disabled**%0A%0A%60auth_request%20%2Fauthenticate%60%20has%20been%20commented%20out%2C%20removing%20JWT%20verification%20from%20all%20DICOMweb%20%28%60%2Fdicomweb%2F%60%29%20requests.%20Any%20client%20that%20can%20reach%20the%20nginx%20proxy%20can%20now%20query%20or%20retrieve%20DICOM%20studies%20without%20a%20valid%20session.%20If%20this%20was%20disabled%20for%20debugging%20purposes%2C%20it%20should%20not%20be%20merged%20in%20this%20state.%0A%0A%23%23%23%20Issue%204%20of%209%0Asrc%2Fcare_radiology%2Fapi%2Fwebhooks.py%3A252-265%0A**Hardcoded%20%60localhost%3A9000%60%20breaks%20containerized%20deployments**%0A%0ABoth%20the%20%60set_tags_url%60%20and%20%60login_url%60%20point%20to%20%60http%3A%2F%2Flocalhost%3A9000%60.%20In%20the%20Docker%20Compose%20stack%20in%20this%20repo%2C%20the%20CARE%20backend%20is%20a%20separate%20container%20and%20is%20not%20accessible%20at%20%60localhost%60%20from%20inside%20the%20radiology%20container.%20This%20means%20the%20MPPS%20tag-update%20flow%20will%20always%20fail%20with%20a%20connection-refused%20error%20in%20the%20deployed%20stack.%20These%20URLs%20should%20be%20read%20from%20%60settings.PLUGIN_CONFIGS%60%20or%20an%20environment%20variable%20so%20they%20can%20be%20configured%20per%20environment.%0A%0A%23%23%23%20Issue%205%20of%209%0Asrc%2Fcare_radiology%2Fapi%2Fdicom.py%3A175-178%0A**%60upload_response.json%28%29%60%20raises%20an%20exception%20when%20the%20response%20body%20is%20not%20JSON**%0A%0ALine%20178%20calls%20%60upload_response.json%28%29%60%20unconditionally%20in%20the%20error%20path.%20When%20DCM4CHE%20returns%20a%20non-JSON%20error%20body%20%28e.g.%20an%20HTML%20error%20page%20or%20plain%20text%29%2C%20this%20raises%20%60ValueError%60%2F%60JSONDecodeError%60.%20The%20outer%20%60except%20Exception%20as%20e%60%20at%20line%20189%20then%20catches%20it%20and%20returns%20HTTP%20500%20with%20%60%22Exception%20occurred%22%60%20instead%20of%20the%20intended%20HTTP%20502%20with%20%60%22Failed%20to%20upload%20to%20DCM4CHE%22%60.%20Wrap%20this%20call%20in%20a%20try%2Fexcept%20or%20use%20%60upload_response.text%60%20only.%0A%0A%284%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=care-ecosystem%2Fcare_radiology&pr=79&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["added mpps\_handler"](https://github.com/care-ecosystem/care_radiology/commit/403b8ba83994e89d2a322f7357255c5a72e7e48a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40483980)</sub>

> Greptile also left **8 inline comments** on this PR.

<!-- /greptile_comment -->